### PR TITLE
Fix TypeError «getFirstErrors(): Return value must be of type array, …

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,11 @@ A simple version of the request model looks like the following:
 
 ```php
 use Yiisoft\RequestModel\RequestModel;
-use Yiisoft\RequestModel\ValidatableModelInterface;
+use Yiisoft\Validator\RulesProviderInterface;
 use Yiisoft\Validator\Rule\Required;
+use Yiisoft\Validator\Rule\Email;
 
-final class AuthRequest extends RequestModel implements ValidatableModelInterface
+final class AuthRequest extends RequestModel implements RulesProviderInterface
 {
     public function getLogin(): string
     {
@@ -52,6 +53,7 @@ final class AuthRequest extends RequestModel implements ValidatableModelInterfac
         return [
             'body.login' => [
                 Required::rule(),
+                Email::rule(),
             ],
             'body.password' => [
                 Required::rule(),

--- a/src/RequestModelFactory.php
+++ b/src/RequestModelFactory.php
@@ -52,7 +52,7 @@ final class RequestModelFactory
         if ($model instanceof RulesProviderInterface) {
             $result = $this->validator->validate($model, $model->getRules());
             if (!$result->isValid()) {
-                throw new RequestValidationException($result->getErrorMessages());
+                throw new RequestValidationException($result->getErrorMessagesIndexedByAttribute());
             }
         }
 

--- a/src/RequestValidationException.php
+++ b/src/RequestValidationException.php
@@ -9,13 +9,16 @@ use RuntimeException;
 final class RequestValidationException extends RuntimeException
 {
     private const MESSAGE = 'Request model validation error';
+
     /**
-     * @psalm-var array<string, non-empty-list<string> $errors
+     * @psalm-var array<string,string[]> $errors
      */
     private array $errors;
 
     /**
      * @param string[] $errors
+     *
+     * @psalm-param array<string,string[]> $errors
      */
     public function __construct(array $errors)
     {
@@ -23,11 +26,17 @@ final class RequestValidationException extends RuntimeException
         parent::__construct(self::MESSAGE);
     }
 
+    /**
+     * @psalm-return array<string,string[]>
+     */
     public function getErrors(): array
     {
         return $this->errors;
     }
 
+    /**
+     * @psalm-return array<string,string>
+     */
     public function getFirstErrors(): array
     {
         if (empty($this->errors)) {

--- a/src/RequestValidationException.php
+++ b/src/RequestValidationException.php
@@ -30,7 +30,18 @@ final class RequestValidationException extends RuntimeException
 
     public function getFirstErrors(): array
     {
-        return empty($this->errors) ? [] : reset($this->errors);
+        if (empty($this->errors)) {
+            return [];
+        }
+
+        $result = [];
+        foreach ($this->errors as $name => $errors) {
+            if (!empty($errors)) {
+                $result[$name] = reset($errors);
+            }
+        }
+
+        return $result;
     }
 
     public function getFirstError(): ?string

--- a/tests/RequestValidationExceptionTest.php
+++ b/tests/RequestValidationExceptionTest.php
@@ -29,8 +29,8 @@ class RequestValidationExceptionTest extends TestCase
     {
         $this->assertEquals(
             [
-                'Bad Value',
-                'Wrong type value',
+                'sort' => 'Bad Value',
+                'page' => 'Bad value',
             ],
             $this->createException()->getFirstErrors()
         );


### PR DESCRIPTION
…string returned»

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

